### PR TITLE
fix: zero deposit and claim after vesting end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ deploy-escrow-seam-transfer-strategy-tenderly	:; forge script script/EscrowSeamT
 
 deploy-erc20-transfer-strategy-base-mainnet	:; forge script script/ERC20TransferStrategy.s.sol:ERC20TransferStrategyScript --force --rpc-url ${BASE_RPC_URL} --slow --broadcast --verify --delay 5 --verifier-url ${VERIFIER_URL} -vvvv
 deploy-erc20-transfer-strategy-tenderly		:; forge script script/ERC20TransferStrategy.s.sol:ERC20TransferStrategyScript --force --rpc-url ${TENDERLY_FORK_RPC_URL} --slow --broadcast -vvvv
+
+deploy-escrow-seam-implementation-base-mainnet	:; forge script script/EscrowSeamImplementationDeploy.s.sol:EscrowSeamImplementationDeploy --force --rpc-url ${BASE_RPC_URL} --slow --broadcast --verify --delay 5 --verifier-url ${VERIFIER_URL} -vvvv
+deploy-escrow-seam-implementation-tenderly		:; forge script script/EscrowSeamImplementationDeploy.s.sol:EscrowSeamImplementationDeploy --force --rpc-url ${TENDERLY_FORK_RPC_URL} --slow --broadcast -vvvv

--- a/script/EscrowSeamImplementationDeploy.s.sol
+++ b/script/EscrowSeamImplementationDeploy.s.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import {EscrowSeam} from "../src/EscrowSeam.sol";
+
+contract EscrowSeamImplementationDeploy is Script {
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+
+        console.log("Deployer address: ", deployerAddress);
+        console.log("Deployer balance: ", deployerAddress.balance);
+        console.log("BlockNumber: ", block.number);
+        console.log("ChainId: ", block.chainid);
+
+        console.log("Deploying...");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        EscrowSeam esSEAM = new EscrowSeam();
+        console.log("EscrowSeam implementation contract deployed at: ", address(esSEAM));
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/EscrowSeam.sol
+++ b/src/EscrowSeam.sol
@@ -88,7 +88,7 @@ contract EscrowSeam is IEscrowSeam, ERC20Upgradeable, ERC20VotesUpgradeable, Own
     function getClaimableAmount(address account) public view returns (uint256) {
         Storage.VestingData storage vestingData = Storage.layout().vestingInfo[account];
 
-        if (vestingData.lastUpdatedTimestamp > vestingData.vestingEndsAt) return 0;
+        if (vestingData.lastUpdatedTimestamp > vestingData.vestingEndsAt) return vestingData.claimableAmount;
 
         uint256 timeDiff = Math.min(block.timestamp, vestingData.vestingEndsAt) - vestingData.lastUpdatedTimestamp;
         uint256 vestedAmount = Math.mulDiv(timeDiff, vestingData.vestPerSecond, MULTIPLIER);

--- a/src/EscrowSeam.sol
+++ b/src/EscrowSeam.sol
@@ -95,7 +95,7 @@ contract EscrowSeam is IEscrowSeam, ERC20Upgradeable, ERC20VotesUpgradeable, Own
     /// @inheritdoc IEscrowSeam
     function deposit(address onBehalfOf, uint256 amount) external {
         if (amount == 0) {
-            revert ZeroAmount();
+            return;
         }
 
         _updateVesting(onBehalfOf);

--- a/src/EscrowSeam.sol
+++ b/src/EscrowSeam.sol
@@ -87,6 +87,9 @@ contract EscrowSeam is IEscrowSeam, ERC20Upgradeable, ERC20VotesUpgradeable, Own
     /// @inheritdoc IEscrowSeam
     function getClaimableAmount(address account) public view returns (uint256) {
         Storage.VestingData storage vestingData = Storage.layout().vestingInfo[account];
+
+        if (vestingData.lastUpdatedTimestamp > vestingData.vestingEndsAt) return 0;
+
         uint256 timeDiff = Math.min(block.timestamp, vestingData.vestingEndsAt) - vestingData.lastUpdatedTimestamp;
         uint256 vestedAmount = Math.mulDiv(timeDiff, vestingData.vestPerSecond, MULTIPLIER);
         return vestingData.claimableAmount + vestedAmount;

--- a/src/interfaces/IEscrowSeam.sol
+++ b/src/interfaces/IEscrowSeam.sol
@@ -9,9 +9,6 @@ interface IEscrowSeam is IERC20 {
     /// @notice EscrowSeam: non-transferable
     error NonTransferable();
 
-    /// @notice Cannot vest zero amount
-    error ZeroAmount();
-
     /// @notice Emitted when SEAM token is deposited(vested) for user.
     /// @param from Account that deposited(vested) SEAM token
     /// @param onBehalfOf Account that SEAM token is deposited(vested) for

--- a/test/fork/EscrowSeamVestingEndsAtZeroBug.t.sol
+++ b/test/fork/EscrowSeamVestingEndsAtZeroBug.t.sol
@@ -36,24 +36,33 @@ contract EscrowSeamVestingEndsAtZeroBugForkTest is Test {
         esSEAM.deposit(BUGGED_USER, depositAmount);
     }
 
-    function testBuggedUserShouldNotRevertAfterUpgrade() public {
-        address newEscrowSeamImplementation = address(new EscrowSeam());
-        vm.prank(Constants.LONG_TIMELOCK_ADDRESS);
-        esSEAM.upgradeToAndCall(newEscrowSeamImplementation, "");
+    function testFuzzBuggedUserShouldNotRevertAfterUpgrade(uint256 depositAmount) public {
+        _upgradeEscrowSeam();
 
         // getClaimableAmount must not revert
         esSEAM.getClaimableAmount(BUGGED_USER);
 
+        depositAmount = bound(depositAmount, 1, type(uint256).max / 1 ether);
+
         // deposit must not revert
-        uint256 depositAmount = 10 ether;
         deal(address(SEAM), address(this), depositAmount);
         SEAM.approve(address(esSEAM), depositAmount);
         esSEAM.deposit(BUGGED_USER, depositAmount);
 
-        // deposit 0 amount must not revert
-        esSEAM.deposit(BUGGED_USER, 0);
-
         (,, uint256 vestingEndsAt,) = esSEAM.vestingInfo(BUGGED_USER);
         assertGt(vestingEndsAt, 0);
+    }
+
+    function testFuzzZeroDepositShouldNotRevertAfterUpgrade(address account) public {
+        _upgradeEscrowSeam();
+
+        // deposit 0 amount must not revert
+        esSEAM.deposit(account, 0);
+    }
+
+    function _upgradeEscrowSeam() internal {
+        address newEscrowSeamImplementation = address(new EscrowSeam());
+        vm.prank(Constants.LONG_TIMELOCK_ADDRESS);
+        esSEAM.upgradeToAndCall(newEscrowSeamImplementation, "");
     }
 }

--- a/test/fork/EscrowSeamVestingEndsAtZeroBug.t.sol
+++ b/test/fork/EscrowSeamVestingEndsAtZeroBug.t.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "openzeppelin-contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Seam} from "../../src/Seam.sol";
+import {EscrowSeam} from "../../src/EscrowSeam.sol";
+import {SeamGovernor} from "../../src/SeamGovernor.sol";
+import {Constants} from "../../src/library/Constants.sol";
+
+contract EscrowSeamVestingEndsAtZeroBugForkTest is Test {
+    Seam public SEAM = Seam(Constants.SEAM_ADDRESS);
+    EscrowSeam public esSEAM = EscrowSeam(Constants.ESCROW_SEAM_ADDRESS);
+
+    // one address of the user which had 0 amount claim bug
+    address public constant BUGGED_USER = 0x8d8335751DEFdfe2207e8DeCd67e462a08988844;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("BASE_RPC_URL"), 18130000);
+    }
+
+    function testConfirmBuggedUserState() public {
+        (,, uint256 vestingEndsAt, uint256 lastUpdatedTimestamp) = esSEAM.vestingInfo(BUGGED_USER);
+        assertEq(vestingEndsAt, 0);
+        assertGt(lastUpdatedTimestamp, 0);
+    }
+
+    function testBuggedUserReverts_getClaimableAmount_deposit() public {
+        vm.expectRevert(stdError.arithmeticError);
+        esSEAM.getClaimableAmount(BUGGED_USER);
+
+        uint256 depositAmount = 10 ether;
+        deal(address(SEAM), address(this), depositAmount);
+        SEAM.approve(address(esSEAM), depositAmount);
+        vm.expectRevert(stdError.arithmeticError);
+        esSEAM.deposit(BUGGED_USER, depositAmount);
+    }
+
+    function testBuggedUserShouldNotRevertAfterUpgrade() public {
+        address newEscrowSeamImplementation = address(new EscrowSeam());
+        vm.prank(Constants.LONG_TIMELOCK_ADDRESS);
+        esSEAM.upgradeToAndCall(newEscrowSeamImplementation, "");
+
+        // getClaimableAmount must not revert
+        esSEAM.getClaimableAmount(BUGGED_USER);
+
+        // deposit must not revert
+        uint256 depositAmount = 10 ether;
+        deal(address(SEAM), address(this), depositAmount);
+        SEAM.approve(address(esSEAM), depositAmount);
+        esSEAM.deposit(BUGGED_USER, depositAmount);
+
+        // deposit 0 amount must not revert
+        esSEAM.deposit(BUGGED_USER, 0);
+
+        (,, uint256 vestingEndsAt,) = esSEAM.vestingInfo(BUGGED_USER);
+        assertGt(vestingEndsAt, 0);
+    }
+}

--- a/test/fork/EscrowSeamVestingEndsAtZeroBug.t.sol
+++ b/test/fork/EscrowSeamVestingEndsAtZeroBug.t.sol
@@ -16,7 +16,7 @@ contract EscrowSeamVestingEndsAtZeroBugForkTest is Test {
     address public constant BUGGED_USER = 0x8d8335751DEFdfe2207e8DeCd67e462a08988844;
 
     function setUp() public {
-        vm.createSelectFork(vm.envString("BASE_RPC_URL"), 18130000);
+        vm.createSelectFork(vm.envString("FORK_URL"), 18130000);
     }
 
     function testConfirmBuggedUserState() public {

--- a/test/fork/Seam.t.sol
+++ b/test/fork/Seam.t.sol
@@ -12,7 +12,7 @@ contract SeamForkTest is Test {
     SeamGovernor public governor = SeamGovernor(payable(Constants.GOVERNOR_SHORT_ADDRESS));
 
     function setUp() public {
-        vm.createSelectFork(vm.envString("BASE_RPC_URL"), 7567615);
+        vm.createSelectFork(vm.envString("FORK_URL"), 7567615);
     }
 
     function testUpgrade() public {

--- a/test/fork/Seam.t.sol
+++ b/test/fork/Seam.t.sol
@@ -12,7 +12,7 @@ contract SeamForkTest is Test {
     SeamGovernor public governor = SeamGovernor(payable(Constants.GOVERNOR_SHORT_ADDRESS));
 
     function setUp() public {
-        vm.createSelectFork(vm.envString("FORK_URL"), 7567615);
+        vm.createSelectFork(vm.envString("BASE_RPC_URL"), 7567615);
     }
 
     function testUpgrade() public {

--- a/test/unit/EscrowSeam.t.sol
+++ b/test/unit/EscrowSeam.t.sol
@@ -107,7 +107,7 @@ contract EscrowSeamTest is Test {
         assertEq(lastUpdatedTimestamp, block.timestamp);
     }
 
-    function testFuzzDepositZeroAmountShouldNotRevert_ShouldNotChangeVestingInfo(address account) public {
+    function testFuzzDepositZeroAmountShouldNotChangeVestingInfo(address account) public {
         (
             uint256 claimableAmountBefore,
             uint256 decreasePerSecondBefore,

--- a/test/unit/EscrowSeam.t.sol
+++ b/test/unit/EscrowSeam.t.sol
@@ -109,18 +109,18 @@ contract EscrowSeamTest is Test {
 
     function testFuzzDepositZeroAmountShouldNotRevert_ShouldNotChangeVestingInfo(address account) public {
         (
-            uint256 claimableAmountBefore, 
-            uint256 decreasePerSecondBefore, 
-            uint256 vestingEndsAtBefore, 
+            uint256 claimableAmountBefore,
+            uint256 decreasePerSecondBefore,
+            uint256 vestingEndsAtBefore,
             uint256 lastUpdatedTimestampBefore
         ) = esSEAM.vestingInfo(account);
-        
+
         esSEAM.deposit(account, 0);
 
         (
-            uint256 claimableAmountAfter, 
-            uint256 decreasePerSecondAfter, 
-            uint256 vestingEndsAtAfter, 
+            uint256 claimableAmountAfter,
+            uint256 decreasePerSecondAfter,
+            uint256 vestingEndsAtAfter,
             uint256 lastUpdatedTimestampAfter
         ) = esSEAM.vestingInfo(account);
 

--- a/test/unit/EscrowSeam.t.sol
+++ b/test/unit/EscrowSeam.t.sol
@@ -160,4 +160,33 @@ contract EscrowSeamTest is Test {
         esSEAM.delegate(address(this));
         assertEq(esSEAM.getVotes(address(this)), esSEAM.totalSupply());
     }
+
+    function testClaimBeforeDeposit_ShouldNotRevert() public {
+        address account = makeAddr("account");
+
+        vm.mockCall(seam, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+        esSEAM.claim(account);
+
+        // deposit after claim should not revert
+        uint256 depositAmount = 10 ether;
+        vm.mockCall(seam, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+        esSEAM.deposit(account, depositAmount);
+    }
+
+    function testClaimAfterVestingEnd_DepositShouldNotRevert() public {
+        address account = makeAddr("account");
+        uint256 depositAmount = 10 ether;
+
+        vm.mockCall(seam, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+        esSEAM.deposit(account, depositAmount);
+
+        vm.warp(block.timestamp + VESTING_DURATION * 2);
+
+        vm.mockCall(seam, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+        esSEAM.claim(account);
+
+        // deposit after claim should not revert
+        vm.mockCall(seam, abi.encodeWithSelector(IERC20.transfer.selector), abi.encode(true));
+        esSEAM.deposit(account, depositAmount);
+    }
 }

--- a/test/unit/EscrowSeam.t.sol
+++ b/test/unit/EscrowSeam.t.sol
@@ -107,8 +107,7 @@ contract EscrowSeamTest is Test {
         assertEq(lastUpdatedTimestamp, block.timestamp);
     }
 
-    function testFuzzDepositRevertZeroAmount(address account) public {
-        vm.expectRevert(IEscrowSeam.ZeroAmount.selector);
+    function testFuzzDepositZeroAmountShouldNotRevert(address account) public {
         esSEAM.deposit(account, 0);
     }
 

--- a/test/unit/EscrowSeam.t.sol
+++ b/test/unit/EscrowSeam.t.sol
@@ -107,8 +107,27 @@ contract EscrowSeamTest is Test {
         assertEq(lastUpdatedTimestamp, block.timestamp);
     }
 
-    function testFuzzDepositZeroAmountShouldNotRevert(address account) public {
+    function testFuzzDepositZeroAmountShouldNotRevert_ShouldNotChangeVestingInfo(address account) public {
+        (
+            uint256 claimableAmountBefore, 
+            uint256 decreasePerSecondBefore, 
+            uint256 vestingEndsAtBefore, 
+            uint256 lastUpdatedTimestampBefore
+        ) = esSEAM.vestingInfo(account);
+        
         esSEAM.deposit(account, 0);
+
+        (
+            uint256 claimableAmountAfter, 
+            uint256 decreasePerSecondAfter, 
+            uint256 vestingEndsAtAfter, 
+            uint256 lastUpdatedTimestampAfter
+        ) = esSEAM.vestingInfo(account);
+
+        assertEq(claimableAmountBefore, claimableAmountAfter);
+        assertEq(decreasePerSecondBefore, decreasePerSecondAfter);
+        assertEq(vestingEndsAtBefore, vestingEndsAtAfter);
+        assertEq(lastUpdatedTimestampBefore, lastUpdatedTimestampAfter);
     }
 
     function testClaim() public {

--- a/test/unit/transfer-strategies/ERC20TransferStrategy.t.sol
+++ b/test/unit/transfer-strategies/ERC20TransferStrategy.t.sol
@@ -45,7 +45,7 @@ contract ERC20TransferStrategyTest is Test {
     }
 
     function testFuzz_EmergencyTransfer(address to, uint256 amount) public {
-        vm.assume(to != address(0));
+        vm.assume(to != address(0) && to != address(strategy));
 
         uint256 strategyBalanceBefore = type(uint256).max;
         deal(address(rewardToken), address(strategy), strategyBalanceBefore);

--- a/test/unit/transfer-strategies/EscrowSeamTransferStrategy.t.sol
+++ b/test/unit/transfer-strategies/EscrowSeamTransferStrategy.t.sol
@@ -45,14 +45,14 @@ contract EscrowSeamTransferStrategyTest is Test {
         public
     {
         vm.assume(caller != incentivesController);
-        vm.startPrank(user);
+        vm.startPrank(caller);
         vm.expectRevert(ITransferStrategyBase.NotIncentivesController.selector);
         strategy.performTransfer(user, address(0), amount);
         vm.stopPrank();
     }
 
     function testFuzz_EmergencyTransfer(address to, uint256 amount) public {
-        vm.assume(to != address(0));
+        vm.assume(to != address(0) && to != address(strategy));
 
         uint256 strategyBalanceBefore = type(uint256).max;
         deal(address(seam), address(strategy), strategyBalanceBefore);

--- a/test/unit/transfer-strategies/SeamTransferStrategy.t.sol
+++ b/test/unit/transfer-strategies/SeamTransferStrategy.t.sol
@@ -39,7 +39,7 @@ contract SeamTransferStrategyTest is Test {
         public
     {
         vm.assume(caller != incentivesController);
-        vm.startPrank(user);
+        vm.startPrank(caller);
         vm.expectRevert(ITransferStrategyBase.NotIncentivesController.selector);
         strategy.performTransfer(user, address(0), amount);
         vm.stopPrank();


### PR DESCRIPTION
This PR makes two fixes:

1. Don't revert on deposits with 0 amount
2. Fix `getClaimableAmount` function to not revert when `lastUpdatedTimestamp` is bigger than `vestingEndsAt`