### PR TITLE
Feat/staking custom rates

### DIFF
--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -14,7 +14,9 @@ interface IRewardKeeper {
     event SetPeriod(uint256 period);
     event ManualWithdraw(address token, address receiver, uint256 amount);
     event AllowedManualTokenUpdated(address token, bool allowed);
-    event ManualClaimedAndSetRate(address token, uint88 emissionRate, uint32 deadline);
+    event ManualSetRate(address token, uint88 emissionRate, uint32 deadline);
+    event ConfiguredAsset(address reward, uint88 rate, uint256 time);
+    event TransferStrategySet(address reward, address strategy);
 
     error ZeroAddress(address target);
     error InsufficientTimeElapsed();
@@ -71,8 +73,15 @@ interface IRewardKeeper {
     function emergencyWithdrawalFromTransferStrategy(address token, address to, uint256 amt) external;
 
     /**
+     * @notice Sets a transfer strategy for a given reward token.
+     * @param rewardToken address of the reward token
+     * @param transferStrategy address of the new transfer strategy
+     */
+    function setTransferStrategy(address rewardToken, address transferStrategy) external;
+
+    /**
      * @notice Sets whether a given token is allowed to be used with the manual reward setter.
-     * @dev CAUTION: Should not be used with static tokens
+     * @dev CAUTION: Should not be used with any fee tokens accrued by via the pool
      * @param token The underlying token address to update.
      * @param allowed True if the token should be allowed; false otherwise.
      */

--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -172,7 +172,5 @@ interface IRewardKeeper {
      * @param token address of token
      * @return flag (bool).
      */
-    function getIsAllowedForManualRate(address token) external view returns(bool);
-
-
+    function getIsAllowedForManualRate(address token) external view returns (bool);
 }

--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -90,7 +90,7 @@ interface IRewardKeeper {
      * - strategyType >= 2 will revert unless upgraded to support other types.
      */
     function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType) external;
-    
+
     /**
      * @notice Sets reward rates manually for specific tokens
      * @dev intended for use with non-static tokens

--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -13,11 +13,16 @@ interface IRewardKeeper {
     event SetPool(address pool);
     event SetPeriod(uint256 period);
     event ManualWithdraw(address token, address receiver, uint256 amount);
+    event AllowedManualTokenUpdated(address token, bool allowed);
+    event ManualClaimedAndSetRate(address token, uint88 emissionRate, uint32 deadline);
 
     error ZeroAddress(address target);
     error InsufficientTimeElapsed();
     error InvalidPeriod();
     error TransferStrategyNotSet();
+    error StaticTokenCannotBeSetManually();
+    error setManualRateNotAuthorized();
+    error InvalidManualRateParams();
 
     /**
      * @notice Pauses the contract, disabling state-changing operations.
@@ -61,6 +66,22 @@ interface IRewardKeeper {
      * @param amt The amount of tokens to withdraw.
      */
     function emergencyWithdrawalFromTransferStrategy(address token, address to, uint256 amt) external;
+
+    /**
+     * @notice Sets whether a given token is allowed to be used with the manual reward setter.
+     * @param token The underlying token address to update.
+     * @param allowed True if the token should be allowed; false otherwise.
+     */
+    function setTokenForManualRate(address token, bool allowed) external;
+
+    /**
+     * @notice Sets reward rates manually for specific tokens
+     * @dev intended for use with non-static tokens
+     * @param rewardToken address of the reward token to add.
+     * @param rate the emission rate
+     * @param timespan the amount of time for the rewards to emit
+     */
+    function setManualRate(address rewardToken, uint88 rate, uint256 timespan) external;
 
     /**
      * @notice Performs a manual token withdrawal
@@ -145,4 +166,13 @@ interface IRewardKeeper {
      * @return factory interface.
      */
     function getStaticATokenFactory() external view returns (IStaticATokenFactory);
+
+    /**
+     * @notice Returns a flag indicating if a token address can have manual rate set
+     * @param token address of token
+     * @return flag (bool).
+     */
+    function getIsAllowedForManualRate(address token) external view returns(bool);
+
+
 }

--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -27,7 +27,6 @@ interface IRewardKeeper {
     error InvalidManualRateParams();
     error AssetConfigured();
     error AssetNotConfigured();
-    
 
     /**
      * @notice Pauses the contract, disabling state-changing operations.

--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -27,7 +27,7 @@ interface IRewardKeeper {
     error InvalidManualRateParams();
     error AssetConfigured();
     error AssetNotConfigured();
-    error InvalidStrategyType();
+    
 
     /**
      * @notice Pauses the contract, disabling state-changing operations.
@@ -74,6 +74,7 @@ interface IRewardKeeper {
 
     /**
      * @notice Sets a transfer strategy for a given reward token.
+     * @notice Should withdraw tokens from previous strategy before updating.
      * @param rewardToken address of the reward token
      * @param transferStrategy address of the new transfer strategy
      */
@@ -93,12 +94,9 @@ interface IRewardKeeper {
      * @param rewardToken address of the reward token to add.
      * @param rate the emission rate
      * @param timespan the amount of time for the rewards to emit
-     * @param strategyType selects the type of transfer strategy to deploy.
-     * - contract can be upgraded to allow for additional transfer strategies
-     * - current transfer strategy codes: 0 = ERC20TransferStrategy, 1 = StaticATokenTransferStrategy
-     * - strategyType >= 2 will revert unless upgraded to support other types.
+     * @param transferStrategy address of the transfer strategy to set.
      */
-    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType) external;
+    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, address transferStrategy) external;
 
     /**
      * @notice Sets reward rates manually for specific tokens

--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -21,7 +21,7 @@ interface IRewardKeeper {
     error InvalidPeriod();
     error TransferStrategyNotSet();
     error StaticTokenCannotBeSetManually();
-    error setManualRateNotAuthorized();
+    error SetManualRateNotAuthorized();
     error InvalidManualRateParams();
 
     /**

--- a/src/interfaces/IRewardKeeper.sol
+++ b/src/interfaces/IRewardKeeper.sol
@@ -23,6 +23,9 @@ interface IRewardKeeper {
     error StaticTokenCannotBeSetManually();
     error SetManualRateNotAuthorized();
     error InvalidManualRateParams();
+    error AssetConfigured();
+    error AssetNotConfigured();
+    error InvalidStrategyType();
 
     /**
      * @notice Pauses the contract, disabling state-changing operations.
@@ -69,14 +72,29 @@ interface IRewardKeeper {
 
     /**
      * @notice Sets whether a given token is allowed to be used with the manual reward setter.
+     * @dev CAUTION: Should not be used with static tokens
      * @param token The underlying token address to update.
      * @param allowed True if the token should be allowed; false otherwise.
      */
     function setTokenForManualRate(address token, bool allowed) external;
 
     /**
+     * @notice must be called for reward tokens being set for the first time
+     * @dev Calls "ConfigureAsset" on the reward controller and deploys transfer strategy
+     * @param rewardToken address of the reward token to add.
+     * @param rate the emission rate
+     * @param timespan the amount of time for the rewards to emit
+     * @param strategyType selects the type of transfer strategy to deploy.
+     * - contract can be upgraded to allow for additional transfer strategies
+     * - current transfer strategy codes: 0 = ERC20TransferStrategy, 1 = StaticATokenTransferStrategy
+     * - strategyType >= 2 will revert unless upgraded to support other types.
+     */
+    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType) external;
+    
+    /**
      * @notice Sets reward rates manually for specific tokens
      * @dev intended for use with non-static tokens
+     * @dev rewardToken must be configured first
      * @param rewardToken address of the reward token to add.
      * @param rate the emission rate
      * @param timespan the amount of time for the rewards to emit

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -16,6 +16,7 @@ import {DataTypes} from "@aave/core-v3/contracts/protocol/libraries/types/DataTy
 import {RewardKeeperStorage as Storage} from "../storage/RewardKeeperStorage.sol";
 import {IRewardKeeper} from "../interfaces/IRewardKeeper.sol";
 import {StaticATokenTransferStrategy} from "../transfer-strategies/StaticATokenTransferStrategy.sol";
+import {ERC20TransferStrategy} from "../transfer-strategies/ERC20TransferStrategy.sol";
 import {IStaticATokenFactory} from "static-a-token-v3/src/interfaces/IStaticATokenFactory.sol";
 import {StaticATokenLM} from "static-a-token-v3/src/StaticATokenLM.sol";
 
@@ -25,6 +26,7 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
     bytes32 constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
     bytes32 constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
     bytes32 constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+    bytes32 constant REWARD_SETTER_ROLE = keccak256("REWARD_SETTER_ROLE");
 
     modifier isNotZeroAddress(address target) {
         if (target == address(0)) {
@@ -198,6 +200,77 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
     }
 
     /// @inheritdoc IRewardKeeper
+    function setTokenForManualRate(address token, bool allowed)
+        external
+        override
+        onlyRole(MANAGER_ROLE)
+        isNotZeroAddress(token)
+    {
+        Storage.layout().allowedManualTokens[token] = allowed;
+        emit AllowedManualTokenUpdated(token, allowed);
+    }
+
+    /// @inheritdoc IRewardKeeper
+    function setManualRate(address rewardToken, uint88 rate, uint256 timespan)
+        external
+        override
+        onlyRole(REWARD_SETTER_ROLE)
+        whenNotPaused
+        isNotZeroAddress(rewardToken)
+    {
+        // Ensure that the given token is allowed for manual reward setting.
+        if (!getIsAllowedForManualRate(rewardToken)) {
+            revert setManualRateNotAuthorized();
+        }
+        if (getStaticATokenFactory().getStaticAToken(rewardToken) != address(0)) {
+            revert StaticTokenCannotBeSetManually();
+        }
+        if (rate == 0 || timespan == 0) {
+            revert InvalidManualRateParams();
+        }
+
+        IERC20 token = IERC20(rewardToken);
+        address asset = getAsset();
+        IRewardsController controller = getController();
+        uint32 deadline = uint32(block.timestamp + timespan);
+
+        // Get (or deploy if necessary) the transfer strategy for this static token.
+        ERC20TransferStrategy transferStrategy = ERC20TransferStrategy(
+            controller.getTransferStrategy(rewardToken)
+        );
+        if (address(transferStrategy) == address(0)) {
+            RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](1);
+            transferStrategy = new ERC20TransferStrategy(
+                token,
+                address(controller),
+                address(this)
+            );
+            config[0].emissionPerSecond = 0;
+            config[0].totalSupply = IERC20(rewardToken).totalSupply();
+            config[0].distributionEnd = deadline;
+            config[0].asset = asset;
+            config[0].reward = rewardToken;
+            config[0].transferStrategy = ITransferStrategyBase(address(transferStrategy));
+            config[0].rewardOracle = getOracle();
+            controller.configureAssets(config);
+        }
+
+        // Update the rewards controller with the new emission rate and distribution end.
+        address[] memory rewardTokensArray = new address[](1);
+        rewardTokensArray[0] = rewardToken;
+        uint88[] memory emissionRatesArray = new uint88[](1);
+        emissionRatesArray[0] = rate;
+        controller.setEmissionPerSecond(asset, rewardTokensArray, emissionRatesArray);
+        controller.setDistributionEnd(asset, rewardToken, deadline);
+
+        // Transfer the appropriate amount of static tokens to the transfer strategy.
+        // assumes sender has the tokens and has approved this contract to send into transfer strategy
+        token.safeTransferFrom(msg.sender, address(transferStrategy), rate * timespan);
+
+        emit ManualClaimedAndSetRate(rewardToken, rate, deadline);
+    }
+
+    /// @inheritdoc IRewardKeeper
     function emergencyWithdrawalFromTransferStrategy(address token, address to, uint256 amount)
         external
         override
@@ -283,5 +356,10 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
     /// @inheritdoc IRewardKeeper
     function getTreasury() public view override returns (address) {
         return Storage.layout().treasury;
+    }
+
+    /// @inheritdoc IRewardKeeper
+    function getIsAllowedForManualRate(address token) public view override returns(bool) {
+        return Storage.layout().allowedManualTokens[token];
     }
 }

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -223,22 +223,13 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
             revert AssetNotConfigured();
         }
 
-        // ITransferStrategyBase oldStrategy = ITransferStrategyBase(controller.getTransferStrategy(rewardToken));
-        // uint256 oldStrategyBalance = IERC20(rewardToken).balanceOf(address(oldStrategy));
-
         controller.setTransferStrategy(rewardToken, ITransferStrategyBase(transferStrategy));
-
-        // This does not work because rewardKeeper is not the incentive controller of the transfer strategy...
-        // and the rewardController does not appear to have an emergency withdraw function.
-        // if (oldStrategyBalance > 0) {
-        //     oldStrategy.performTransfer(transferStrategy, rewardToken, oldStrategyBalance);
-        // }
 
         emit TransferStrategySet(rewardToken, transferStrategy);
     }
 
     /// @inheritdoc IRewardKeeper
-    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType)
+    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, address transferStrategy)
         external
         override
         onlyRole(REWARD_SETTER_ROLE)
@@ -248,17 +239,11 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
 
         IERC20 token = IERC20(rewardToken);
         IRewardsController controller = getController();
-        address transferStrategy = controller.getTransferStrategy(rewardToken);
+        address currentStrategy = controller.getTransferStrategy(rewardToken);
         uint32 deadline = uint32(block.timestamp + timespan);
 
-        if (transferStrategy == address(0)) {
-            if (strategyType == 0) {
-                transferStrategy = address(new ERC20TransferStrategy(token, address(controller), address(this)));
-            } else if (strategyType == 1) {
-                transferStrategy = address(new StaticATokenTransferStrategy(token, address(controller), address(this)));
-            } else {
-                revert InvalidStrategyType();
-            }
+        if (currentStrategy != address(0)) {
+            revert AssetConfigured();
         }
 
         RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](1);
@@ -272,11 +257,11 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         controller.configureAssets(config);
 
         if (rate > 0 && rate * timespan > 0) {
-            token.safeTransferFrom(msg.sender, address(transferStrategy), rate * timespan);
+            token.safeTransferFrom(msg.sender, transferStrategy, rate * timespan);
         }
 
         emit ConfiguredAsset(rewardToken, rate, timespan);
-        emit TransferStrategySet(rewardToken, address(transferStrategy));
+        emit TransferStrategySet(rewardToken, transferStrategy);
     }
 
     /// @inheritdoc IRewardKeeper

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -205,7 +205,7 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         override
         onlyRole(MANAGER_ROLE)
         isNotZeroAddress(token)
-    {   
+    {
         // TODO: Is there a better way to check?
         // if (address(StaticATokenLM(token).aToken()) != address(0)) {
         //     revert StaticTokenCannotBeSetManually();
@@ -226,7 +226,7 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         if (!getIsAllowedForManualRate(rewardToken)) {
             revert SetManualRateNotAuthorized();
         }
-        
+
         if (rate == 0 || timespan == 0) {
             revert InvalidManualRateParams();
         }

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -210,6 +210,34 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         emit AllowedManualTokenUpdated(token, allowed);
     }
 
+    /// @inheritdoc IRewardKeeper
+    function setTransferStrategy(address rewardToken, address transferStrategy) 
+        external 
+        override 
+        onlyRole(REWARD_SETTER_ROLE) 
+        isNotZeroAddress(rewardToken) 
+    {
+        IRewardsController controller = getController();
+        (,,uint256 lastUpdate,) = controller.getRewardsData(getAsset(), rewardToken);
+        if (lastUpdate == 0) {
+            revert AssetNotConfigured();
+        }
+
+        // ITransferStrategyBase oldStrategy = ITransferStrategyBase(controller.getTransferStrategy(rewardToken));
+        // uint256 oldStrategyBalance = IERC20(rewardToken).balanceOf(address(oldStrategy));
+
+        controller.setTransferStrategy(rewardToken, ITransferStrategyBase(transferStrategy));
+
+        // This does not work because rewardKeeper is not the incentive controller of the transfer strategy...
+        // and the rewardController does not appear to have an emergency withdraw function.
+        // if (oldStrategyBalance > 0) {
+        //     oldStrategy.performTransfer(transferStrategy, rewardToken, oldStrategyBalance);
+        // }
+
+        emit TransferStrategySet(rewardToken, transferStrategy);
+    }
+
+    /// @inheritdoc IRewardKeeper
     function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType)
         external
         override
@@ -223,16 +251,14 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         address transferStrategy = controller.getTransferStrategy(rewardToken);
         uint32 deadline = uint32(block.timestamp + timespan);
 
-        if (transferStrategy != address(0)) {
-            revert AssetConfigured();
-        }
-
-        if (strategyType == 0) {
-            transferStrategy = address(new ERC20TransferStrategy(token, address(controller), address(this)));
-        } else if (strategyType == 1) {
-            transferStrategy = address(new StaticATokenTransferStrategy(token, address(controller), address(this)));
-        } else {
-            revert InvalidStrategyType();
+        if (transferStrategy == address(0)) {
+            if (strategyType == 0) {
+                transferStrategy = address(new ERC20TransferStrategy(token, address(controller), address(this)));
+            } else if (strategyType == 1) {
+                transferStrategy = address(new StaticATokenTransferStrategy(token, address(controller), address(this)));
+            } else {
+                revert InvalidStrategyType();
+            }
         }
 
         RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](1);
@@ -248,6 +274,9 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         if (rate > 0 && rate * timespan > 0) {
             token.safeTransferFrom(msg.sender, address(transferStrategy), rate * timespan);
         }
+
+        emit ConfiguredAsset(rewardToken, rate, timespan);
+        emit TransferStrategySet(rewardToken, address(transferStrategy));
     }
 
     /// @inheritdoc IRewardKeeper
@@ -289,7 +318,7 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         // assumes sender has the tokens and has approved this contract to send into transfer strategy
         token.safeTransferFrom(msg.sender, address(transferStrategy), rate * timespan);
 
-        emit ManualClaimedAndSetRate(rewardToken, rate, deadline);
+        emit ManualSetRate(rewardToken, rate, deadline);
     }
 
     /**

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -206,12 +206,43 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         onlyRole(MANAGER_ROLE)
         isNotZeroAddress(token)
     {
-        // TODO: Is there a better way to check?
-        // if (address(StaticATokenLM(token).aToken()) != address(0)) {
-        //     revert StaticTokenCannotBeSetManually();
-        // }
         Storage.layout().allowedManualTokens[token] = allowed;
         emit AllowedManualTokenUpdated(token, allowed);
+    }
+
+    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType) external override onlyRole(REWARD_SETTER_ROLE) isNotZeroAddress(rewardToken) {
+        _checkIsManualRateAuthorized(rewardToken);
+
+        IERC20 token = IERC20(rewardToken);
+        IRewardsController controller = getController();
+        address transferStrategy = controller.getTransferStrategy(rewardToken);
+        uint32 deadline = uint32(block.timestamp + timespan);
+
+        if (transferStrategy != address(0)) {
+            revert AssetConfigured();
+        }
+
+        if (strategyType == 0) {
+            transferStrategy = address(new ERC20TransferStrategy(token, address(controller), address(this)));
+        } else if (strategyType == 1) {
+            transferStrategy = address(new StaticATokenTransferStrategy(token, address(controller), address(this)));
+        } else {
+            revert InvalidStrategyType();
+        }
+
+        RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](1);
+        config[0].emissionPerSecond = rate;
+        config[0].totalSupply = IERC20(rewardToken).totalSupply();
+        config[0].distributionEnd = deadline;
+        config[0].asset = getAsset();
+        config[0].reward = rewardToken;
+        config[0].transferStrategy = ITransferStrategyBase(transferStrategy);
+        config[0].rewardOracle = getOracle();
+        controller.configureAssets(config);
+
+        if (rate > 0 && rate * timespan > 0) {
+            token.safeTransferFrom(msg.sender, address(transferStrategy), rate * timespan);
+        }
     }
 
     /// @inheritdoc IRewardKeeper
@@ -219,37 +250,28 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         external
         override
         onlyRole(REWARD_SETTER_ROLE)
-        whenNotPaused
         isNotZeroAddress(rewardToken)
     {
         // Ensure that the given token is allowed for manual reward setting.
-        if (!getIsAllowedForManualRate(rewardToken)) {
-            revert SetManualRateNotAuthorized();
-        }
+        _checkIsManualRateAuthorized(rewardToken);
 
         if (rate == 0 || timespan == 0) {
             revert InvalidManualRateParams();
         }
 
+        IRewardsController controller = getController();
+        ERC20TransferStrategy transferStrategy = ERC20TransferStrategy(controller.getTransferStrategy(rewardToken));
+        if (address(transferStrategy) == address(0)) {
+            revert AssetNotConfigured();
+        }
+
         IERC20 token = IERC20(rewardToken);
         address asset = getAsset();
-        IRewardsController controller = getController();
+        
         uint32 deadline = uint32(block.timestamp + timespan);
 
         // Get (or deploy if necessary) the transfer strategy for this static token.
-        ERC20TransferStrategy transferStrategy = ERC20TransferStrategy(controller.getTransferStrategy(rewardToken));
-        if (address(transferStrategy) == address(0)) {
-            RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](1);
-            transferStrategy = new ERC20TransferStrategy(token, address(controller), address(this));
-            config[0].emissionPerSecond = 0;
-            config[0].totalSupply = IERC20(rewardToken).totalSupply();
-            config[0].distributionEnd = deadline;
-            config[0].asset = asset;
-            config[0].reward = rewardToken;
-            config[0].transferStrategy = ITransferStrategyBase(address(transferStrategy));
-            config[0].rewardOracle = getOracle();
-            controller.configureAssets(config);
-        }
+        
 
         // Update the rewards controller with the new emission rate and distribution end.
         address[] memory rewardTokensArray = new address[](1);
@@ -264,6 +286,16 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         token.safeTransferFrom(msg.sender, address(transferStrategy), rate * timespan);
 
         emit ManualClaimedAndSetRate(rewardToken, rate, deadline);
+    }
+
+    /**
+     * @notice Checks if the incoming address has been approved for manual rate
+     * @param rewardToken address of the reward token
+     */
+    function _checkIsManualRateAuthorized(address rewardToken) internal view {
+        if (!getIsAllowedForManualRate(rewardToken)) {
+            revert SetManualRateNotAuthorized();
+        }
     }
 
     /// @inheritdoc IRewardKeeper

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -205,7 +205,11 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         override
         onlyRole(MANAGER_ROLE)
         isNotZeroAddress(token)
-    {
+    {   
+        // TODO: Is there a better way to check?
+        // if (address(StaticATokenLM(token).aToken()) != address(0)) {
+        //     revert StaticTokenCannotBeSetManually();
+        // }
         Storage.layout().allowedManualTokens[token] = allowed;
         emit AllowedManualTokenUpdated(token, allowed);
     }
@@ -220,11 +224,9 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
     {
         // Ensure that the given token is allowed for manual reward setting.
         if (!getIsAllowedForManualRate(rewardToken)) {
-            revert setManualRateNotAuthorized();
+            revert SetManualRateNotAuthorized();
         }
-        if (getStaticATokenFactory().getStaticAToken(rewardToken) != address(0)) {
-            revert StaticTokenCannotBeSetManually();
-        }
+        
         if (rate == 0 || timespan == 0) {
             revert InvalidManualRateParams();
         }

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -210,7 +210,12 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         emit AllowedManualTokenUpdated(token, allowed);
     }
 
-    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType) external override onlyRole(REWARD_SETTER_ROLE) isNotZeroAddress(rewardToken) {
+    function configureAsset(address rewardToken, uint88 rate, uint256 timespan, uint8 strategyType)
+        external
+        override
+        onlyRole(REWARD_SETTER_ROLE)
+        isNotZeroAddress(rewardToken)
+    {
         _checkIsManualRateAuthorized(rewardToken);
 
         IERC20 token = IERC20(rewardToken);
@@ -267,11 +272,10 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
 
         IERC20 token = IERC20(rewardToken);
         address asset = getAsset();
-        
+
         uint32 deadline = uint32(block.timestamp + timespan);
 
         // Get (or deploy if necessary) the transfer strategy for this static token.
-        
 
         // Update the rewards controller with the new emission rate and distribution end.
         address[] memory rewardTokensArray = new address[](1);

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -274,10 +274,6 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         // Ensure that the given token is allowed for manual reward setting.
         _checkIsManualRateAuthorized(rewardToken);
 
-        if (rate == 0 || timespan == 0) {
-            revert InvalidManualRateParams();
-        }
-
         IRewardsController controller = getController();
         ERC20TransferStrategy transferStrategy = ERC20TransferStrategy(controller.getTransferStrategy(rewardToken));
         if (address(transferStrategy) == address(0)) {

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -211,14 +211,14 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
     }
 
     /// @inheritdoc IRewardKeeper
-    function setTransferStrategy(address rewardToken, address transferStrategy) 
-        external 
-        override 
-        onlyRole(REWARD_SETTER_ROLE) 
-        isNotZeroAddress(rewardToken) 
+    function setTransferStrategy(address rewardToken, address transferStrategy)
+        external
+        override
+        onlyRole(REWARD_SETTER_ROLE)
+        isNotZeroAddress(rewardToken)
     {
         IRewardsController controller = getController();
-        (,,uint256 lastUpdate,) = controller.getRewardsData(getAsset(), rewardToken);
+        (,, uint256 lastUpdate,) = controller.getRewardsData(getAsset(), rewardToken);
         if (lastUpdate == 0) {
             revert AssetNotConfigured();
         }

--- a/src/safety-module/RewardKeeper.sol
+++ b/src/safety-module/RewardKeeper.sol
@@ -235,16 +235,10 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
         uint32 deadline = uint32(block.timestamp + timespan);
 
         // Get (or deploy if necessary) the transfer strategy for this static token.
-        ERC20TransferStrategy transferStrategy = ERC20TransferStrategy(
-            controller.getTransferStrategy(rewardToken)
-        );
+        ERC20TransferStrategy transferStrategy = ERC20TransferStrategy(controller.getTransferStrategy(rewardToken));
         if (address(transferStrategy) == address(0)) {
             RewardsDataTypes.RewardsConfigInput[] memory config = new RewardsDataTypes.RewardsConfigInput[](1);
-            transferStrategy = new ERC20TransferStrategy(
-                token,
-                address(controller),
-                address(this)
-            );
+            transferStrategy = new ERC20TransferStrategy(token, address(controller), address(this));
             config[0].emissionPerSecond = 0;
             config[0].totalSupply = IERC20(rewardToken).totalSupply();
             config[0].distributionEnd = deadline;
@@ -359,7 +353,7 @@ contract RewardKeeper is UUPSUpgradeable, AccessControlUpgradeable, PausableUpgr
     }
 
     /// @inheritdoc IRewardKeeper
-    function getIsAllowedForManualRate(address token) public view override returns(bool) {
+    function getIsAllowedForManualRate(address token) public view override returns (bool) {
         return Storage.layout().allowedManualTokens[token];
     }
 }

--- a/src/storage/RewardKeeperStorage.sol
+++ b/src/storage/RewardKeeperStorage.sol
@@ -46,6 +46,10 @@ library RewardKeeperStorage {
          * @notice holds the timestamp of the last time claim was called
          */
         uint256 lastClaim;
+        /**
+         * @notice tracks which ERC20 tokens are allowed to have manual rate set
+         */
+        mapping(address => bool) allowedManualTokens;
     }
 
     bytes32 private constant STORAGE_SLOT = keccak256(

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -455,9 +455,14 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
-        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.AssetConfigured.selector));
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        address strategy = rewardsController.getTransferStrategy(SEAMAddr);
+        deal(SEAMAddr, address(this), 3025);
+        IERC20(SEAMAddr).approve(address(rewardKeeper), 55*55);
+        rewardKeeper.configureAsset(SEAMAddr, 55, 55, 0);
+        address strategyAfter = rewardsController.getTransferStrategy(SEAMAddr);
+        assertTrue(strategy == strategyAfter, "Incorrectly deployed new transfer strategy");
     }
 
     function testSetConfigureAssetsInvalidToken() public {
@@ -607,4 +612,56 @@ contract SeamForkTest is Test {
         uint256 balAfter = IERC20(SEAMAddr).balanceOf(user);
         assertEq(balAfter, balBefore + (rate * time), "Wrong reward distribution");
     }
+
+    function testSetTransferStrategyNotConfigured() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.AssetNotConfigured.selector));
+        rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
+
+    }
+
+    function testSetTransferStrategy() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
+
+        address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
+        assertEq(transferStrat, address(rewardKeeper));
+    }
+
+    // function testSetTransferStrategyWithTransfer() public {
+    //     vm.startPrank(admin);
+    //     rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+    //     rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+    //     vm.stopPrank();
+    //     address SEAMAddr = Constants.SEAM_ADDRESS;
+
+    //     rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+    //     deal(SEAMAddr, address(this), 100);
+    //     IERC20(SEAMAddr).approve(address(rewardKeeper), 10000000000000000000000000000);
+    //     rewardKeeper.configureAsset(SEAMAddr, 10, 10, 0);
+    //     uint256 balBefore = IERC20(SEAMAddr).balanceOf(address(rewardKeeper));
+    //     assertEq(balBefore, 0);
+    //     rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
+
+    //     address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
+    //     assertEq(transferStrat, address(rewardKeeper));
+
+    //     uint256 balStrat = IERC20(SEAMAddr).balanceOf(address(rewardKeeper));
+    //     assertEq(balStrat, 10 * 10);
+    // }
 }

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -495,7 +495,7 @@ contract SeamForkTest is Test {
         rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
         vm.stopPrank();
         address SEAMAddr = Constants.SEAM_ADDRESS;
-        
+
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
 
@@ -585,7 +585,6 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        
 
         deal(asset, user, 1000 ether);
         vm.startPrank(user);
@@ -608,6 +607,4 @@ contract SeamForkTest is Test {
         uint256 balAfter = IERC20(SEAMAddr).balanceOf(user);
         assertEq(balAfter, balBefore + (rate * time), "Wrong reward distribution");
     }
-
-
 }

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -401,7 +401,6 @@ contract SeamForkTest is Test {
         rewardKeeper.setTokenForManualRate(SEAMAddr, false);
         status = rewardKeeper.getIsAllowedForManualRate(SEAMAddr);
         assertTrue(!status, "Wrong removal");
-
     }
 
     // function testSetTokenRevertsWithStaticToken() public {
@@ -442,7 +441,6 @@ contract SeamForkTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
         rewardKeeper.setManualRate(SEAMAddr, 5, 0);
-
     }
 
     function testSetManualRate() public {
@@ -466,7 +464,7 @@ contract SeamForkTest is Test {
         uint256 time = 7 days;
         uint256 rate = uint256(500 ether / time);
         IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
-        
+
         rewardKeeper.setManualRate(SEAMAddr, uint88(rate), time);
 
         address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
@@ -502,7 +500,7 @@ contract SeamForkTest is Test {
         uint256 time = 7 days;
         uint256 rate = uint256(500 ether / time);
         IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
-        
+
         rewardKeeper.setManualRate(SEAMAddr, uint88(rate), time);
 
         vm.warp(block.timestamp + 8 days);

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -178,7 +178,6 @@ contract SeamForkTest is Test {
 
     function testClaim() public {
         rewardKeeper.claimAndSetRate();
-        address[] memory rewardTokens = pool.getReservesList();
         address[] memory assets = new address[](1);
         assets[0] = address(stkSEAM);
 
@@ -200,7 +199,6 @@ contract SeamForkTest is Test {
         userCount = bound(userCount, 1, 100);
 
         rewardKeeper.claimAndSetRate();
-        address[] memory rewardTokens = pool.getReservesList();
         address[] memory assets = new address[](1);
         assets[0] = address(stkSEAM);
 
@@ -418,7 +416,7 @@ contract SeamForkTest is Test {
         rewardKeeper.setManualRate(address(0), 5, 200);
     }
 
-    function testSetManualRateInvalidParams() public {
+    function testSetManualRateWorksWithZero() public {
         vm.startPrank(admin);
         rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
         rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
@@ -430,12 +428,12 @@ contract SeamForkTest is Test {
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
 
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
-
-        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
+        deal(SEAMAddr, address(this), 1000000 ether);
+        IERC20(SEAMAddr).approve(address(rewardKeeper), 10000000000 ether);
+        
         rewardKeeper.setManualRate(SEAMAddr, 0, 200);
-
-        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
         rewardKeeper.setManualRate(SEAMAddr, 5, 0);
+        rewardKeeper.setManualRate(SEAMAddr, 0, 0);
     }
 
     function testSetConfigureAssetsAlreadyConfigured() public {

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -455,11 +455,11 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        
+
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
         address strategy = rewardsController.getTransferStrategy(SEAMAddr);
         deal(SEAMAddr, address(this), 3025);
-        IERC20(SEAMAddr).approve(address(rewardKeeper), 55*55);
+        IERC20(SEAMAddr).approve(address(rewardKeeper), 55 * 55);
         rewardKeeper.configureAsset(SEAMAddr, 55, 55, 0);
         address strategyAfter = rewardsController.getTransferStrategy(SEAMAddr);
         assertTrue(strategy == strategyAfter, "Incorrectly deployed new transfer strategy");
@@ -621,10 +621,9 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        
+
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.AssetNotConfigured.selector));
         rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
-
     }
 
     function testSetTransferStrategy() public {
@@ -635,7 +634,7 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        
+
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
         rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
 

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -430,7 +430,7 @@ contract SeamForkTest is Test {
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
         deal(SEAMAddr, address(this), 1000000 ether);
         IERC20(SEAMAddr).approve(address(rewardKeeper), 10000000000 ether);
-        
+
         rewardKeeper.setManualRate(SEAMAddr, 0, 200);
         rewardKeeper.setManualRate(SEAMAddr, 5, 0);
         rewardKeeper.setManualRate(SEAMAddr, 0, 0);

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -386,4 +386,130 @@ contract SeamForkTest is Test {
             assertTrue(timesSuccessful > 0, "Not successful");
         }
     }
+
+    // test manual rates
+    function testSetTokenForManualRates() public {
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+        vm.prank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.ZeroAddress.selector, address(0)));
+        rewardKeeper.setTokenForManualRate(address(0), true);
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        bool status = rewardKeeper.getIsAllowedForManualRate(SEAMAddr);
+        assertTrue(status, "Wrong assignment");
+        rewardKeeper.setTokenForManualRate(SEAMAddr, false);
+        status = rewardKeeper.getIsAllowedForManualRate(SEAMAddr);
+        assertTrue(!status, "Wrong removal");
+
+    }
+
+    // function testSetTokenRevertsWithStaticToken() public {
+    //     address[] memory rewardTokens = pool.getReservesList();
+    //     address staticAToken = IStaticATokenFactory(factory).getStaticAToken(rewardTokens[0]);
+    //     vm.prank(admin);
+    //     rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+
+    //     vm.expectRevert();
+    //     rewardKeeper.setTokenForManualRate(staticAToken, true);
+
+    // }
+
+    function testSetManualRateUnauthorizedToken() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.SetManualRateNotAuthorized.selector));
+        rewardKeeper.setManualRate(address(2), 5, 200);
+
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.ZeroAddress.selector, address(0)));
+        rewardKeeper.setManualRate(address(0), 5, 200);
+    }
+
+    function testSetManualRateInvalidParams() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
+        rewardKeeper.setManualRate(SEAMAddr, 0, 200);
+
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
+        rewardKeeper.setManualRate(SEAMAddr, 5, 0);
+
+    }
+
+    function testSetManualRate() public {
+        rewardKeeper.claimAndSetRate();
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+
+        deal(asset, user, 1000 ether);
+        vm.startPrank(user);
+        IERC20(asset).approve(address(stkSEAM), 1000 ether);
+        stkSEAM.deposit(1000 ether, user);
+        vm.stopPrank();
+        vm.warp(block.timestamp + 10);
+
+        deal(SEAMAddr, address(this), 500 ether);
+        uint256 time = 7 days;
+        uint256 rate = uint256(500 ether / time);
+        IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
+        
+        rewardKeeper.setManualRate(SEAMAddr, uint88(rate), time);
+
+        address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
+        assertTrue(transferStrat != address(0), "Transfer Strategy Not Deployed");
+
+        uint256 balTStrat = IERC20(SEAMAddr).balanceOf(transferStrat);
+        assertTrue(balTStrat == rate * time, "Wrong balance");
+
+        uint256 distributionEnd = rewardsController.getDistributionEnd(address(stkSEAM), SEAMAddr);
+        assertEq(distributionEnd, block.timestamp + 7 days, "Wrong distribution end");
+    }
+
+    function testSetManualRateCorrectlyEmits() public {
+        address[] memory assets = new address[](1);
+        assets[0] = address(stkSEAM);
+        rewardKeeper.claimAndSetRate();
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+
+        deal(asset, user, 1000 ether);
+        vm.startPrank(user);
+        IERC20(asset).approve(address(stkSEAM), 1000 ether);
+        stkSEAM.deposit(1000 ether, user);
+        vm.stopPrank();
+        vm.warp(block.timestamp + 10);
+
+        deal(SEAMAddr, address(this), 500 ether);
+        uint256 time = 7 days;
+        uint256 rate = uint256(500 ether / time);
+        IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
+        
+        rewardKeeper.setManualRate(SEAMAddr, uint88(rate), time);
+
+        vm.warp(block.timestamp + 8 days);
+        uint256 balBefore = IERC20(SEAMAddr).balanceOf(user);
+        vm.prank(user);
+        rewardsController.claimAllRewards(assets, user);
+        uint256 balAfter = IERC20(SEAMAddr).balanceOf(user);
+        assertEq(balAfter, balBefore + (rate * time), "Wrong reward distribution");
+    }
 }

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -403,17 +403,6 @@ contract SeamForkTest is Test {
         assertTrue(!status, "Wrong removal");
     }
 
-    // function testSetTokenRevertsWithStaticToken() public {
-    //     address[] memory rewardTokens = pool.getReservesList();
-    //     address staticAToken = IStaticATokenFactory(factory).getStaticAToken(rewardTokens[0]);
-    //     vm.prank(admin);
-    //     rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
-
-    //     vm.expectRevert();
-    //     rewardKeeper.setTokenForManualRate(staticAToken, true);
-
-    // }
-
     function testSetManualRateUnauthorizedToken() public {
         vm.startPrank(admin);
         rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
@@ -436,11 +425,83 @@ contract SeamForkTest is Test {
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
 
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
         rewardKeeper.setManualRate(SEAMAddr, 0, 200);
 
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
         rewardKeeper.setManualRate(SEAMAddr, 5, 0);
+    }
+
+    function testSetConfigureAssetsWrongStrategyType() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidStrategyType.selector));
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 3);
+    }
+
+    function testSetConfigureAssetsAlreadyConfigured() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.AssetConfigured.selector));
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+    }
+
+    function testSetConfigureAssetsInvalidToken() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.SetManualRateNotAuthorized.selector));
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+    }
+
+    function testSetConfigureAssetsCorrectlySends() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+        deal(SEAMAddr, address(this), 500 ether);
+        uint256 time = 7 days;
+        uint256 rate = uint256(500 ether / time);
+        IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, 0);
+
+        address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
+        uint256 balTStrat = IERC20(SEAMAddr).balanceOf(transferStrat);
+        assertTrue(balTStrat == rate * time, "Wrong balance");
+    }
+
+    function testSetConfigureAssetsCorrectlyDoesNotSend() public {
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+        
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+
+        address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
+        uint256 balTStrat = IERC20(SEAMAddr).balanceOf(transferStrat);
+        assertTrue(balTStrat == 0, "Wrong balance");
     }
 
     function testSetManualRate() public {
@@ -452,6 +513,7 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
 
         deal(asset, user, 1000 ether);
         vm.startPrank(user);
@@ -488,6 +550,7 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
 
         deal(asset, user, 1000 ether);
         vm.startPrank(user);
@@ -510,4 +573,41 @@ contract SeamForkTest is Test {
         uint256 balAfter = IERC20(SEAMAddr).balanceOf(user);
         assertEq(balAfter, balBefore + (rate * time), "Wrong reward distribution");
     }
+
+    function testSetManualRateFromConfigureAssets() public {
+        address[] memory assets = new address[](1);
+        assets[0] = address(stkSEAM);
+        rewardKeeper.claimAndSetRate();
+        vm.startPrank(admin);
+        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
+        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
+        vm.stopPrank();
+        address SEAMAddr = Constants.SEAM_ADDRESS;
+
+        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        
+
+        deal(asset, user, 1000 ether);
+        vm.startPrank(user);
+        IERC20(asset).approve(address(stkSEAM), 1000 ether);
+        stkSEAM.deposit(1000 ether, user);
+        vm.stopPrank();
+        vm.warp(block.timestamp + 10);
+
+        deal(SEAMAddr, address(this), 500 ether);
+        uint256 time = 7 days;
+        uint256 rate = uint256(500 ether / time);
+        IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
+
+        rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, 0);
+
+        vm.warp(block.timestamp + 8 days);
+        uint256 balBefore = IERC20(SEAMAddr).balanceOf(user);
+        vm.prank(user);
+        rewardsController.claimAllRewards(assets, user);
+        uint256 balAfter = IERC20(SEAMAddr).balanceOf(user);
+        assertEq(balAfter, balBefore + (rate * time), "Wrong reward distribution");
+    }
+
+
 }

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -425,7 +425,7 @@ contract SeamForkTest is Test {
         vm.stopPrank();
         address SEAMAddr = Constants.SEAM_ADDRESS;
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
 
@@ -447,15 +447,14 @@ contract SeamForkTest is Test {
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
-        
+
         deal(SEAMAddr, address(this), 3025);
         IERC20(SEAMAddr).approve(address(rewardKeeper), 55 * 55);
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.AssetConfigured.selector));
         rewardKeeper.configureAsset(SEAMAddr, 55, 55, address(transferStrategy));
-        
     }
 
     function testSetConfigureAssetsInvalidToken() public {
@@ -466,7 +465,7 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.SetManualRateNotAuthorized.selector));
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
@@ -484,7 +483,7 @@ contract SeamForkTest is Test {
         IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
         rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, address(transferStrategy));
 
         address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
@@ -501,7 +500,7 @@ contract SeamForkTest is Test {
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
 
         address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
@@ -519,7 +518,7 @@ contract SeamForkTest is Test {
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
 
         deal(asset, user, 1000 ether);
@@ -557,7 +556,7 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
@@ -609,7 +608,7 @@ contract SeamForkTest is Test {
         IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
 
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
         rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, address(transferStrategy));
 
@@ -644,7 +643,7 @@ contract SeamForkTest is Test {
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
 
         ERC20TransferStrategy transferStrategy =
-                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+            new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
         rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
         rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
@@ -652,5 +651,4 @@ contract SeamForkTest is Test {
         address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
         assertEq(transferStrat, address(rewardKeeper));
     }
-
 }

--- a/test/fork/SafetyModule.t.sol
+++ b/test/fork/SafetyModule.t.sol
@@ -8,8 +8,10 @@ import {Constants} from "../../src/library/Constants.sol";
 import {StakedToken} from "../../src/safety-module/StakedToken.sol";
 import {RewardKeeper} from "../../src/safety-module/RewardKeeper.sol"; // Adjust import paths to your project structure
 import {IRewardKeeper} from "../../src/interfaces/IRewardKeeper.sol";
+import {ERC20TransferStrategy} from "../../src/transfer-strategies/ERC20TransferStrategy.sol";
 import {RewardKeeperStorage as StorageLib} from "../../src/storage/RewardKeeperStorage.sol";
 import {IERC20} from "@aave/core-v3/contracts/dependencies/openzeppelin/contracts/IERC20.sol";
+import {IERC20 as ierc20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 import {IPool} from "@aave/core-v3/contracts/interfaces/IPool.sol";
 import {IRewardsController} from "aave-v3-periphery/contracts/rewards/interfaces/IRewardsController.sol";
 import {IEACAggregatorProxy} from "@aave/periphery-v3/contracts/misc/interfaces/IEACAggregatorProxy.sol";
@@ -422,29 +424,18 @@ contract SeamForkTest is Test {
         rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
         vm.stopPrank();
         address SEAMAddr = Constants.SEAM_ADDRESS;
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
 
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
 
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
         rewardKeeper.setManualRate(SEAMAddr, 0, 200);
 
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidManualRateParams.selector));
         rewardKeeper.setManualRate(SEAMAddr, 5, 0);
-    }
-
-    function testSetConfigureAssetsWrongStrategyType() public {
-        vm.startPrank(admin);
-        rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
-        rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
-        vm.stopPrank();
-        address SEAMAddr = Constants.SEAM_ADDRESS;
-
-        rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-
-        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.InvalidStrategyType.selector));
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 3);
     }
 
     function testSetConfigureAssetsAlreadyConfigured() public {
@@ -455,14 +446,16 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
 
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
-        address strategy = rewardsController.getTransferStrategy(SEAMAddr);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
+        
         deal(SEAMAddr, address(this), 3025);
         IERC20(SEAMAddr).approve(address(rewardKeeper), 55 * 55);
-        rewardKeeper.configureAsset(SEAMAddr, 55, 55, 0);
-        address strategyAfter = rewardsController.getTransferStrategy(SEAMAddr);
-        assertTrue(strategy == strategyAfter, "Incorrectly deployed new transfer strategy");
+        vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.AssetConfigured.selector));
+        rewardKeeper.configureAsset(SEAMAddr, 55, 55, address(transferStrategy));
+        
     }
 
     function testSetConfigureAssetsInvalidToken() public {
@@ -472,8 +465,11 @@ contract SeamForkTest is Test {
         vm.stopPrank();
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+
         vm.expectRevert(abi.encodeWithSelector(IRewardKeeper.SetManualRateNotAuthorized.selector));
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
     }
 
     function testSetConfigureAssetsCorrectlySends() public {
@@ -487,7 +483,9 @@ contract SeamForkTest is Test {
         uint256 rate = uint256(500 ether / time);
         IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, 0);
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+        rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, address(transferStrategy));
 
         address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
         uint256 balTStrat = IERC20(SEAMAddr).balanceOf(transferStrat);
@@ -502,7 +500,9 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
 
         address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
         uint256 balTStrat = IERC20(SEAMAddr).balanceOf(transferStrat);
@@ -518,7 +518,9 @@ contract SeamForkTest is Test {
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
 
         deal(asset, user, 1000 ether);
         vm.startPrank(user);
@@ -554,8 +556,11 @@ contract SeamForkTest is Test {
         vm.stopPrank();
         address SEAMAddr = Constants.SEAM_ADDRESS;
 
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
 
         deal(asset, user, 1000 ether);
         vm.startPrank(user);
@@ -603,7 +608,10 @@ contract SeamForkTest is Test {
         uint256 rate = uint256(500 ether / time);
         IERC20(SEAMAddr).approve(address(rewardKeeper), rate * time);
 
-        rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, 0);
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+
+        rewardKeeper.configureAsset(SEAMAddr, uint88(rate), time, address(transferStrategy));
 
         vm.warp(block.timestamp + 8 days);
         uint256 balBefore = IERC20(SEAMAddr).balanceOf(user);
@@ -635,32 +643,14 @@ contract SeamForkTest is Test {
 
         rewardKeeper.setTokenForManualRate(SEAMAddr, true);
 
-        rewardKeeper.configureAsset(SEAMAddr, 0, 0, 0);
+        ERC20TransferStrategy transferStrategy =
+                    new ERC20TransferStrategy(ierc20(address(SEAMAddr)), address(rewardsController), address(rewardKeeper));
+
+        rewardKeeper.configureAsset(SEAMAddr, 0, 0, address(transferStrategy));
         rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
 
         address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
         assertEq(transferStrat, address(rewardKeeper));
     }
 
-    // function testSetTransferStrategyWithTransfer() public {
-    //     vm.startPrank(admin);
-    //     rewardKeeper.grantRole(keccak256("MANAGER_ROLE"), address(this));
-    //     rewardKeeper.grantRole(keccak256("REWARD_SETTER_ROLE"), address(this));
-    //     vm.stopPrank();
-    //     address SEAMAddr = Constants.SEAM_ADDRESS;
-
-    //     rewardKeeper.setTokenForManualRate(SEAMAddr, true);
-    //     deal(SEAMAddr, address(this), 100);
-    //     IERC20(SEAMAddr).approve(address(rewardKeeper), 10000000000000000000000000000);
-    //     rewardKeeper.configureAsset(SEAMAddr, 10, 10, 0);
-    //     uint256 balBefore = IERC20(SEAMAddr).balanceOf(address(rewardKeeper));
-    //     assertEq(balBefore, 0);
-    //     rewardKeeper.setTransferStrategy(SEAMAddr, address(rewardKeeper));
-
-    //     address transferStrat = rewardsController.getTransferStrategy(SEAMAddr);
-    //     assertEq(transferStrat, address(rewardKeeper));
-
-    //     uint256 balStrat = IERC20(SEAMAddr).balanceOf(address(rewardKeeper));
-    //     assertEq(balStrat, 10 * 10);
-    // }
 }


### PR DESCRIPTION
Added ability to assign rate/deadline manually to a reward token. Assumes sender (who requires role) has the tokens and has approved the rewardKeeper. RewardKeeper sends tokens to a ERC20 transfer strategy. This is currently NOT compatible with any staticATokens, as staticATokens should only be assigned via the main function.